### PR TITLE
Made gantt-addon compatible with JDK1.8 by fixing Javadoc.

### DIFF
--- a/gantt-addon/src/main/java/org/tltv/gantt/Gantt.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/Gantt.java
@@ -159,11 +159,11 @@ public class Gantt extends com.vaadin.ui.AbstractComponent implements
     /**
      * Set start date of the Gantt chart's timeline. When resolution is
      * {@link Resolution#Day} or {@link Resolution#Week}, time will be adjusted
-     * to a minimum possible for the given date (1/1/2010 12:12:12 => 1/1/20120
+     * to a minimum possible for the given date (1/1/2010 12:12:12 &rarr; 1/1/20120
      * 00:00:00).
      * <p>
      * For {@link Resolution#Hour}, given date is adjusted like this: 1/1/2010
-     * 12:12:12 => 1/1/2010 12:00:00.
+     * 12:12:12 &rarr; 1/1/2010 12:00:00.
      * 
      * @param date
      */
@@ -179,7 +179,7 @@ public class Gantt extends com.vaadin.ui.AbstractComponent implements
     /**
      * Set end date of the Gantt chart's timeline. When resolution is
      * {@link Resolution#Day} or {@link Resolution#Week}, time will be adjusted
-     * to a maximum possible for the given date (1/1/2010 12:12:12 => 1/1/20120
+     * to a maximum possible for the given date (1/1/2010 12:12:12 &rarr; 1/1/20120
      * 23:59:59).
      * 
      * @param date
@@ -461,7 +461,7 @@ public class Gantt extends com.vaadin.ui.AbstractComponent implements
      * Set timeline's week row's week format for {@link Resolution#Week}
      * resolution. Default is week number.
      * 
-     * @param format
+     * @param weekFormat
      *            Format string like 'dd'
      */
     public void setTimelineWeekFormat(String weekFormat) {
@@ -481,7 +481,7 @@ public class Gantt extends com.vaadin.ui.AbstractComponent implements
      * Set timeline's day row's format for {@link Resolution#Hour} resolution.
      * Default is number of day in month.
      * 
-     * @param format
+     * @param dayFormat
      *            Format string like 'dd'
      */
     public void setTimelineDayFormat(String dayFormat) {

--- a/gantt-addon/src/main/java/org/tltv/gantt/client/AbstractStepWidget.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/AbstractStepWidget.java
@@ -63,7 +63,7 @@ public class AbstractStepWidget extends ComplexPanel {
     }
 
     /**
-     * Set data source for this widget. Called when {@linkplain StepState#state}
+     * Set data source for this widget. Called when {@linkplain StepState}
      * is changed.
      * 
      * @param step

--- a/gantt-addon/src/main/java/org/tltv/gantt/client/GanttDateTimeService.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/GanttDateTimeService.java
@@ -47,8 +47,6 @@ public class GanttDateTimeService extends DateTimeService {
      *            The date to convert
      * @param formatStr
      *            The format string that might contain MMM or MMMM
-     * @param dateTimeService
-     *            Reference to the Vaadin DateTimeService
      * @return
      */
     @Override

--- a/gantt-addon/src/main/java/org/tltv/gantt/client/GanttWidget.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/GanttWidget.java
@@ -85,7 +85,7 @@ import com.vaadin.client.event.PointerUpHandler;
  * <p>
  * Timeline's localization is handled via {@link LocaleDataProvider}.
  * <p>
- * Here are few steps that need to be notified when taking this widget in use. <br/>
+ * Here are few steps that need to be notified when taking this widget in use. <br>
  * First of all, after constructing this widget, you need to initialize it by
  * {@link #initWidget(GanttRpc, LocaleDataProvider)} method. But before doing
  * that, make sure to call
@@ -96,14 +96,12 @@ import com.vaadin.client.event.PointerUpHandler;
  * <p>
  * Sample code snippet:
  * 
- * <code>
  * <pre>
  * GanttWidget widget = new GanttWidget();    
  * widget.setBrowserInfo(isIe(), isIe8(), isIe9(), isChrome(), isSafari(), isWebkit());
  * widget.setTouchSupportted(isTouchDevice());
  * widget.initWidget(ganttRpc, localeDataProvider);
  * </pre>
- * </code>
  * <p>
  * After initializing, widget is ready to go. But to let this widget know when
  * it should re-calculate content widths/heights, call either
@@ -871,7 +869,7 @@ public class GanttWidget extends ComplexPanel implements HasEnabled, HasWidgets 
     }
 
     /**
-     * @see {@link TimelineWidget#setAlwaysCalculatePixelWidths(boolean)}
+     * @see TimelineWidget#setAlwaysCalculatePixelWidths(boolean)
      * @param calcPx
      */
     public void setAlwaysCalculatePixelWidths(boolean calcPx) {
@@ -880,7 +878,7 @@ public class GanttWidget extends ComplexPanel implements HasEnabled, HasWidgets 
 
     /**
      * Sets timeline's force update flag up. Next
-     * {@link TimelineWidget#update(Resolution, long, long, int, LocaleDataProvider)}
+     * {@link TimelineWidget#update(Resolution, long, long, int, int, LocaleDataProvider)}
      * call knows then to update everything.
      */
     public void setForceUpdateTimeline() {

--- a/gantt-addon/src/main/java/org/tltv/gantt/client/TimelineWidget.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/TimelineWidget.java
@@ -61,7 +61,7 @@ import com.google.gwt.user.client.ui.Widget;
  * <p>
  * There's always a minimum width calculated and updated to the timeline
  * element. Percentage values set some limitation for the component's width.
- * Wider the component (> 4000px), bigger the change to get year, month and date
+ * Wider the component (&gt; 4000px), bigger the change to get year, month and date
  * blocks not being vertically in-line with each others.
  * <p>
  * Supports setting a scroll left position.
@@ -196,7 +196,7 @@ public class TimelineWidget extends Widget {
 
     /**
      * Constructs the widget. Call
-     * {@link #update(Resolution, long, long, int, LocaleDataProvider)} after
+     * {@link #update(Resolution, long, long, int, int, LocaleDataProvider)} after
      * the component is attached to some parent widget.
      */
     public TimelineWidget() {
@@ -353,7 +353,7 @@ public class TimelineWidget extends Widget {
 
     /**
      * Set minimum width (pixels) of this widget's root DIV element. Default is
-     * -1. Notice that {@link #update(Resolution, long, long)} will calculate
+     * -1. Notice that {@link #update(Resolution, long, long, int, int, LocaleDataProvider)} will calculate
      * min-width and call this internally.
      * 
      * @param minWidth
@@ -400,7 +400,7 @@ public class TimelineWidget extends Widget {
      * Calculate CSS value for 'left' property matching left offset in
      * percentage for a date ( {@link Date#getTime()}).
      * <p>
-     * May return '2.123456%' or 'calc(2.123456%)' if IE(>8);
+     * May return '2.123456%' or 'calc(2.123456%)' if IE(&gt;8);
      * 
      * @param date
      *            Target date in milliseconds.
@@ -440,7 +440,7 @@ public class TimelineWidget extends Widget {
      * Calculate CSS value for 'width' property matching date interval inside
      * the time-line. Returns percentage value. Interval is in milliseconds.
      * <p>
-     * May return '2.123456%' or 'calc(2.123456%)' if IE(>8);
+     * May return '2.123456%' or 'calc(2.123456%)' if IE(&gt;8);
      * 
      * @param interval
      *            Date interval in milliseconds.
@@ -451,7 +451,7 @@ public class TimelineWidget extends Widget {
         return getWidthPercentageStringForDateInterval(interval, range);
     }
 
-    /** @see {@link #getWidthPercentageStringForDateInterval(long)} */
+    /** @see #getWidthPercentageStringForDateInterval(long) */
     public String getWidthPercentageStringForDateInterval(long interval,
             double range) {
         String calc = createCalcCssValue(range, interval);
@@ -698,7 +698,6 @@ public class TimelineWidget extends Widget {
      * Default value is false.
      * 
      * @param calcPx
-     * @return
      */
     public void setAlwaysCalculatePixelWidths(boolean calcPx) {
         calcPixels = calcPx;
@@ -812,7 +811,7 @@ public class TimelineWidget extends Widget {
 
     /**
      * Sets force update flag up. Next
-     * {@link #update(Resolution, long, long, int, LocaleDataProvider)} call
+     * {@link #update(Resolution, long, long, int, int, LocaleDataProvider)} call
      * knows then to update everything.
      */
     public void setForceUpdate() {


### PR DESCRIPTION
mvn clean install failed before when JDK 1.8 was used since doclint is
enabled.

http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html