### PR TITLE
enable/disable movement per steps

### DIFF
--- a/gantt-addon/src/main/java/org/tltv/gantt/client/GanttWidget.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/GanttWidget.java
@@ -1479,7 +1479,7 @@ public class GanttWidget extends ComplexPanel implements HasEnabled, HasWidgets 
                 } else {
                     resetBarPosition(bar);
                 }
-            } else if (isMovableSteps()) {
+            } else if (isMovableStep(bar) ) {
                 // moving in progress
                 removeMovingStyles(bar);
                 if (moveInProgress) {
@@ -1552,7 +1552,7 @@ public class GanttWidget extends ComplexPanel implements HasEnabled, HasWidgets 
             }
             addResizingStyles(bar);
             bar.getStyle().clearBackgroundColor();
-        } else if (isMovableSteps()) {
+        } else if (isMovableStep(bar)) {
             updateMoveInProgressFlag(bar, deltax, deltay);
             updateBarMovingPosition(bar, deltax);
             addMovingStyles(bar);
@@ -1972,6 +1972,15 @@ public class GanttWidget extends ComplexPanel implements HasEnabled, HasWidgets 
         AbstractStepWidget step = getAbstractStepWidget(bar);
         return step != null && step.getStep() != null
                 && step.getStep().isResizable();
+    }
+
+    private boolean isMovableStep(Element bar) {
+        if (!isMovableSteps()) {
+            return false;
+        }
+        AbstractStepWidget step = getAbstractStepWidget(bar);
+        return step != null && step.getStep() != null
+                && step.getStep().isMovable();
     }
 
     private boolean isResizingLeft(Element bar) {

--- a/gantt-addon/src/main/java/org/tltv/gantt/client/shared/AbstractStep.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/shared/AbstractStep.java
@@ -30,6 +30,7 @@ public abstract class AbstractStep implements Serializable {
     private double progress;
     private boolean showProgress;
     private boolean resizable = true;
+    private boolean movable = true;
 
     private long startDate = -1;
     private long endDate = -1;
@@ -187,6 +188,14 @@ public abstract class AbstractStep implements Serializable {
 
     public void setResizable(boolean resizable) {
         this.resizable = resizable;
+    }
+
+    public boolean isMovable() {
+        return movable;
+    }
+
+    public void setMovable(boolean movable) {
+        this.movable = movable;
     }
 
     public enum CaptionMode {


### PR DESCRIPTION
I added setMovable() setter to AbstractStep (similar to setResizable()) so the movement can be disabled for steps if the gantt.movableSteps is true.