### PR TITLE
Add option to use own (Sub)StepComponents

### DIFF
--- a/gantt-addon/src/main/java/org/tltv/gantt/Gantt.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/Gantt.java
@@ -412,15 +412,11 @@ public class Gantt extends AbstractComponent implements HasComponents {
         if (uid == null) {
             return null;
         }
-        AbstractStep key = new Step();
-        key.setUid(uid);
 
         StepComponent sc = stepComponents.get(uid);
         if (sc != null) {
             return sc.getState().step;
         }
-        key = new SubStep();
-        key.setUid(uid);
         SubStepComponent sub = subStepMap.get(uid);
         if (sub != null) {
             return sub.getState().step;

--- a/gantt-addon/src/main/java/org/tltv/gantt/StepComponent.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/StepComponent.java
@@ -1,30 +1,31 @@
 package org.tltv.gantt;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
-
+import com.vaadin.shared.Connector;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.HasComponents;
 import org.tltv.gantt.client.shared.Step;
 import org.tltv.gantt.client.shared.StepState;
 import org.tltv.gantt.client.shared.SubStep;
 import org.tltv.gantt.client.shared.SubStepObserver;
 import org.tltv.gantt.client.shared.SubStepObserverProxy;
 
-import com.vaadin.shared.Connector;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.HasComponents;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Component representing a Step in the Gantt chart.
- * 
+ *
  * @author Tltv
- * 
+ *
  */
 public class StepComponent extends AbstractStepComponent implements
         HasComponents, SubStepObserver {
 
     protected Gantt gantt;
+
+    private SubStepComponentFactory subStepComponentFactory = new SubStepComponentFactory();
 
     public StepComponent(Gantt gantt, Step data) {
         this.gantt = gantt;
@@ -58,7 +59,7 @@ public class StepComponent extends AbstractStepComponent implements
 
     protected SubStepComponent createSubStepComponent(
             StepComponent stepComponent, SubStep subStep) {
-        return new SubStepComponent(stepComponent, subStep);
+        return this.subStepComponentFactory.create(stepComponent, subStep);
     }
 
     @Override
@@ -74,20 +75,23 @@ public class StepComponent extends AbstractStepComponent implements
     public void onAddSubStep(SubStep subStep) {
         SubStepComponent component = createSubStepComponent(this, subStep);
         getState(true).subSteps.add(component);
-        gantt.subStepMap.put(subStep, component);
+        gantt.subStepMap.put(subStep.getUid(), component);
         gantt.adjustDatesByAbstractStep(subStep.getOwner());
     }
 
     /** Detach sub-step component from the UI. */
     @Override
     public void onRemoveSubStep(SubStep subStep) {
-        SubStepComponent component = gantt.subStepMap.get(subStep);
+        SubStepComponent component = gantt.subStepMap.get(subStep.getUid());
         if (component != null) {
             component.setParent(null);
             getState(true).subSteps.remove(component);
         }
-        gantt.subStepMap.remove(subStep);
+        gantt.subStepMap.remove(subStep.getUid());
         gantt.adjustDatesByAbstractStep(subStep.getOwner());
     }
 
+    public void setSubStepComponentFactory(SubStepComponentFactory subStepComponentFactory) {
+        this.subStepComponentFactory = subStepComponentFactory;
+    }
 }

--- a/gantt-addon/src/main/java/org/tltv/gantt/StepComponentFactory.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/StepComponentFactory.java
@@ -1,0 +1,10 @@
+package org.tltv.gantt;
+
+import org.tltv.gantt.client.shared.Step;
+
+public class StepComponentFactory {
+
+    public StepComponent create(Gantt gantt, Step step) {
+        return new StepComponent(gantt, step);
+    }
+}

--- a/gantt-addon/src/main/java/org/tltv/gantt/SubStepComponentFactory.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/SubStepComponentFactory.java
@@ -1,0 +1,10 @@
+package org.tltv.gantt;
+
+import org.tltv.gantt.client.shared.SubStep;
+
+public class SubStepComponentFactory {
+
+    public SubStepComponent create(StepComponent stepComponent, SubStep subStep) {
+        return new SubStepComponent(stepComponent, subStep);
+    }
+}

--- a/gantt-addon/src/main/java/org/tltv/gantt/client/TimelineWidget.java
+++ b/gantt-addon/src/main/java/org/tltv/gantt/client/TimelineWidget.java
@@ -16,20 +16,6 @@
 
 package org.tltv.gantt.client;
 
-import static org.tltv.gantt.client.shared.GanttUtil.getBoundingClientRectLeft;
-import static org.tltv.gantt.client.shared.GanttUtil.getBoundingClientRectRight;
-import static org.tltv.gantt.client.shared.GanttUtil.getBoundingClientRectWidth;
-
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import org.tltv.gantt.client.shared.GanttUtil;
-import org.tltv.gantt.client.shared.Resolution;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Element;
@@ -45,10 +31,23 @@ import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.AbstractNativeScrollbar;
 import com.google.gwt.user.client.ui.Widget;
+import org.tltv.gantt.client.shared.GanttUtil;
+import org.tltv.gantt.client.shared.Resolution;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.tltv.gantt.client.shared.GanttUtil.getBoundingClientRectLeft;
+import static org.tltv.gantt.client.shared.GanttUtil.getBoundingClientRectRight;
+import static org.tltv.gantt.client.shared.GanttUtil.getBoundingClientRectWidth;
 
 /**
  * GWT widget to build a scalable timeline that supports more than one
- * resolutions ({@link org.tltv.gantt.client.shared.Resolution}). When timeline
+ * resolutions ({@link Resolution}). When timeline
  * element doesn't overflow horizontally in it's parent element, it scales the
  * content width up to fit in the space available.
  * <p>
@@ -97,7 +96,7 @@ public class TimelineWidget extends Widget {
     public static final int HOURS_IN_DAY = 24;
     public static final long DAY_INTERVAL = 24 * 60 * 60 * 1000;
     public static final long HOUR_INTERVAL = 60 * 60 * 1000;
-    public static final int RESOLUTION_WEEK_DAYBLOCK_WIDTH = 4;
+    public int resolutionWeekDayblockWidth = 4;
 
     private boolean ie;
 
@@ -249,7 +248,7 @@ public class TimelineWidget extends Widget {
      *
      */
     public void update(Resolution resolution, long startDate, long endDate, int firstDayOfRange, int firstHourOfRange,
-            LocaleDataProvider localeDataProvider) {
+                       LocaleDataProvider localeDataProvider) {
         if (localeDataProvider == null) {
             GWT.log(getClass().getSimpleName() + " requires LocaleDataProvider. Can't complete update(...) operation.");
             return;
@@ -418,7 +417,7 @@ public class TimelineWidget extends Widget {
     }
 
     public String getLeftPositionPercentageStringForDate(long date, double rangeWidth, long rangeStartDate,
-            long rangeEndDate) {
+                                                         long rangeEndDate) {
         double rangeLeft = getLeftPositionForDate(date, rangeWidth, rangeStartDate, rangeEndDate);
         double width = rangeWidth;
         String calc = createCalcCssValue(width, rangeLeft);
@@ -1262,7 +1261,7 @@ public class TimelineWidget extends Widget {
     }
 
     private void prepareTimelineForHourResolution(long interval, long startDate, long endDate,
-            ResolutionBlockRegisterer resBlockRegisterer) {
+                                                  ResolutionBlockRegisterer resBlockRegisterer) {
         blocksInRange = 0;
         resolutionBlockCount = 0;
         firstResBlockCount = 0;
@@ -1298,7 +1297,7 @@ public class TimelineWidget extends Widget {
     }
 
     private void prepareTimelineForResolution(long interval, long startDate, long endDate,
-            ResolutionBlockRegisterer resBlockRegisterer) {
+                                              ResolutionBlockRegisterer resBlockRegisterer) {
         blocksInRange = 0;
         resolutionBlockCount = 0;
         firstResBlockCount = 0;
@@ -1339,7 +1338,7 @@ public class TimelineWidget extends Widget {
     }
 
     private void fillTimelineForResolution(long interval, long startDate, long endDate,
-            ResolutionBlockFiller resBlockFiller) {
+                                           ResolutionBlockFiller resBlockFiller) {
         String currentYear = null;
         long pos = startDate;
         pos = adjustToMiddleOfDay(pos);
@@ -1366,7 +1365,7 @@ public class TimelineWidget extends Widget {
     }
 
     private void fillTimelineForHourResolution(long interval, long startDate, long endDate,
-            ResolutionBlockFiller resBlockFiller) {
+                                               ResolutionBlockFiller resBlockFiller) {
         String currentYear = null;
         long pos = startDate;
         final long end = endDate;
@@ -1729,7 +1728,7 @@ public class TimelineWidget extends Widget {
     }
 
     private void fillWeekResolutionBlock(DivElement resBlock, Date date, int index, Weekday weekDay, boolean firstWeek,
-            boolean lastBlock, int left, boolean even) {
+                                         boolean lastBlock, int left, boolean even) {
         if (resBlock != null) {
             resBlock.setInnerText(formatWeekCaption(date));
 
@@ -1767,7 +1766,7 @@ public class TimelineWidget extends Widget {
     }
 
     private void fillHourResolutionBlock(DivElement resBlock, Date date, int index, int hourCounter, boolean lastBlock,
-            int left, boolean even) {
+                                         int left, boolean even) {
         if (getLocaleDataProvider().isTwelveHourClock()) {
             resBlock.setInnerText(getLocaleDataProvider().formatDate(date, getHour12DateTimeFormat()));
         } else {
@@ -1821,7 +1820,7 @@ public class TimelineWidget extends Widget {
     }
 
     private boolean isChanged(Resolution resolution, long startDate, long endDate, int firstDayOfWeek,
-            int firstDayOfRange, int firstHourOfRange, String locale) {
+                              int firstDayOfRange, int firstHourOfRange, String locale) {
         boolean resolutionChanged = this.resolution != resolution;
         if (resolutionChanged) {
             minResolutionWidth = -1;
@@ -1860,7 +1859,7 @@ public class TimelineWidget extends Widget {
             // divide given width by number of days in week
             width = width / DAYS_IN_WEEK;
         }
-        width = (width < RESOLUTION_WEEK_DAYBLOCK_WIDTH) ? RESOLUTION_WEEK_DAYBLOCK_WIDTH : width;
+        width = (width < resolutionWeekDayblockWidth) ? resolutionWeekDayblockWidth : width;
         resBlockMeasure.removeFromParent();
         if (removeResolutionDiv) {
             resolutionDiv.removeFromParent();
@@ -1929,7 +1928,7 @@ public class TimelineWidget extends Widget {
     }
 
     private double getScrollOverflowForResolutionBlock(double positionLeftSnapshot, int left,
-            boolean firstResBlockShort) {
+                                                       boolean firstResBlockShort) {
         double overflow;
         if (firstResBlockShort && left <= getFirstResolutionElementWidth()) {
             overflow = getScrollOverflowForShortFirstResolutionBlock(positionLeftSnapshot);
@@ -1998,15 +1997,15 @@ public class TimelineWidget extends Widget {
         DivElement element = null;
         for (int i = 0; i < blocks; i++) {
             switch (resolution) {
-            case Hour:
-                element = createHourResolutionBlock();
-                break;
-            case Day:
-                element = createDayResolutionBlock();
-                break;
-            case Week:
-                element = createWeekResolutionBlock();
-                break;
+                case Hour:
+                    element = createHourResolutionBlock();
+                    break;
+                case Day:
+                    element = createDayResolutionBlock();
+                    break;
+                case Week:
+                    element = createWeekResolutionBlock();
+                    break;
             }
             resolutionDiv.appendChild(element);
         }
@@ -2060,5 +2059,17 @@ public class TimelineWidget extends Widget {
             blocks.clear();
             blockLength.clear();
         }
+    }
+
+    public void setHour24DateTimeFormat(DateTimeFormat hour24DateTimeFormat) {
+        this.hour24DateTimeFormat = hour24DateTimeFormat;
+    }
+
+    public void setHour12DateTimeFormat(DateTimeFormat hour12DateTimeFormat) {
+        this.hour12DateTimeFormat = hour12DateTimeFormat;
+    }
+
+    public void setResolutionWeekDayblockWidth(int resolutionWeekDayblockWidth) {
+        this.resolutionWeekDayblockWidth = resolutionWeekDayblockWidth;
     }
 }


### PR DESCRIPTION
- add possibility to inject customized steps and substeps via factories
- by using customized steps/supsteps the method Gantt.getStep(String uid) fails while using maps with steps/substeps as keys due to class comparison in equals method of AbstractStep. Hence, use uid as keys for those maps and hold steps in dedicated set.
- add setters for some date formats and widths